### PR TITLE
Small changes to cultural search

### DIFF
--- a/dplace_app/static/partials/search/cultural.html
+++ b/dplace_app/static/partials/search/cultural.html
@@ -22,7 +22,7 @@
                                 style="width:100%"
                                 ng-change="traitChanged(trait)"
 								ng-show="trait.indexVariables.length > 0"
-                                ng-options="variable.name for variable in trait.indexVariables"
+                                ng-options='variable.name as (variable.label + " - " + variable.name) for variable in trait.indexVariables'
                                 >
                             <option value="">Select a Variable</option>
                         </select>


### PR DESCRIPTION
Location of codebook_info moved (still need to figure out where this should go, though).  Now it's in the same place as codebook_info for environmental search.

Added codepoint info to search dropdowns for cultural search e.g. "EAxxx - variable name" ( #114 )
