### PR TITLE
Add d3 to bower.json

### DIFF
--- a/dplace_app/static/bower.json
+++ b/dplace_app/static/bower.json
@@ -23,6 +23,7 @@
     "angular-ui-bootstrap-bower": "~0.11.0",
     "jquery": "~2.1.1",
     "bootstrap": "~3.1.1",
-    "bower-jvectormap": "~1.2.2"
+    "bower-jvectormap": "~1.2.2",
+    "d3": "~3.4.13"
   }
 }


### PR DESCRIPTION
D3 was already installed in bower_components, but not added to bower.json with --save
