### PR TITLE
Prevent map ID collisions

### DIFF
--- a/dplace_app/static/js/directives.js
+++ b/dplace_app/static/js/directives.js
@@ -1,13 +1,16 @@
 angular.module('dplaceMapDirective', [])
     .directive('dplaceMap', function(colorMapService) {
         function link(scope, element, attrs) {
-            element.append("<div id='mapdiv' style='width:1140px; height:30rem;'></div>");
+            // jVectorMap requires an ID for the element
+            // If not present, default to 'mapDiv'
+            var divId = scope.mapDivId || 'mapDiv';
+            element.append("<div id='" + divId + "' style='width:1140px; height:30rem;'></div>");
             scope.localRegions = [];
             scope.checkDirty = function() {
                 return !(angular.equals(scope.localRegions, scope.selectedRegions));
             };
             scope.updatesEnabled = true;
-            scope.map = $('#mapdiv').vectorMap({
+            scope.map = $('#' + divId).vectorMap({
                 map: 'tdwg-level2_mill_en',
                 backgroundColor: 'white',
                 series: {
@@ -121,7 +124,8 @@ angular.module('dplaceMapDirective', [])
             scope: {
                 societies: '=',
                 region: '=',
-                selectedRegions: '='
+                selectedRegions: '=',
+                mapDivId: '@'
             },
             link: link
         };

--- a/dplace_app/static/partials/search/geographic.html
+++ b/dplace_app/static/partials/search/geographic.html
@@ -21,7 +21,7 @@
                 </span>
             </div>
             <div class="panel-body scrollable">
-                <dplace-map selected-regions="geographic.selectedRegions"></dplace-map>
+                <dplace-map selected-regions="geographic.selectedRegions" map-div-id="search-map"></dplace-map>
             </div>
         </div>
         <div class="pull-right">

--- a/dplace_app/static/partials/societies.html
+++ b/dplace_app/static/partials/societies.html
@@ -45,7 +45,7 @@
             </div>
         </tab>
         <tab heading="Map" select="resizeMap()">
-            <dplace-map societies="results.societies"></dplace-map>
+            <dplace-map societies="results.societies" map-div-id="result-map"></dplace-map>
         </tab>
         <tab heading="Download" select="generateDownloadLinks()">
             <div class="row">


### PR DESCRIPTION
The map div created by jVectorMap will now use a string ID provided in `map-div-id` in the `<dplace-map>` directive tag
