### PR TITLE
Add 'visible' attribute to dplace-map

### DIFF
--- a/dplace_app/static/js/controllers/societies.js
+++ b/dplace_app/static/js/controllers/societies.js
@@ -1,9 +1,6 @@
 function SocietiesCtrl($scope, searchModelService) {
     $scope.results = searchModelService.getModel().getResults();
     $scope.setActive('societies');
-    $scope.resizeMap = function() {
-        $scope.$broadcast('mapTabActivated');
-    };
 
     $scope.generateDownloadLinks = function() {
         // queryObject is the in-memory JS object representing the chosen search options

--- a/dplace_app/static/js/directives.js
+++ b/dplace_app/static/js/directives.js
@@ -3,120 +3,150 @@ angular.module('dplaceMapDirective', [])
         function link(scope, element, attrs) {
             // jVectorMap requires an ID for the element
             // If not present, default to 'mapDiv'
-            var divId = scope.mapDivId || 'mapDiv';
-            element.append("<div id='" + divId + "' style='width:1140px; height:30rem;'></div>");
+            var mapDivId = scope.mapDivId || 'mapDiv';
+            // Not possible to assign default values to bound attributes, so check
+            element.append("<div id='" + mapDivId + "' style='width:1140px; height:30rem;'></div>");
             scope.localRegions = [];
             scope.checkDirty = function() {
                 return !(angular.equals(scope.localRegions, scope.selectedRegions));
             };
             scope.updatesEnabled = true;
-            scope.map = $('#' + divId).vectorMap({
-                map: 'tdwg-level2_mill_en',
-                backgroundColor: 'white',
-                series: {
-                    markers: [{
-                        attribute: 'fill'
-                    }]
-                },
-                regionStyle: {
-                  initial: {
-                    fill: '#428bca',
-                    "fill-opacity": 1,
-                    stroke: '#357ebd',
-                    "stroke-width": 0,
-                    "stroke-opacity": 1
-                  },
-                  hover: {
-                    "fill-opacity": 0.8
-                  },
-                  selected: {
-                    fill: '#113'
-                  },
-                  selectedHover: {
-                  }
-                },
-                onRegionOver: function(e, code) {
-                    if(attrs.region) {
-                        scope.$apply(function () {
-                            scope.region = code;
-                        });
-                    }
-                },
-                onRegionSelected: function(e, code, isSelected, selectedRegionCodes) {
-                    if(scope.updatesEnabled && attrs.selectedRegions) {
-                        scope.localRegions = selectedRegionCodes.map(function(code) {
-                            return {
-                                code: code,
-                                name: scope.map.getRegionName(code)
-                            };
-                        });
-                        var dirty = scope.checkDirty();
-                        if(dirty) {
-                            scope.$apply(function() {
-                                scope.selectedRegions = angular.copy(scope.localRegions);
-                            });
-                        }
-                    }
-                },
-                regionsSelectable: true
-            }).vectorMap('get','mapObject');
-
-            scope.addMarkers = function() {
-                scope.map.removeAllMarkers();
-                if(!scope.societies) {
-                    return;
+            var hideMap = function(scope) {
+                if(angular.isDefined(scope.map)) {
+                    scope.map.remove();
+                    scope.map = undefined;
                 }
-
-                // get the society IDs
-                var societyIds = scope.societies.map(function(societyResult) {
-                    return societyResult.society.id;
-                });
-
-                scope.societies.forEach(function(societyResult) {
-                    var society = societyResult.society;
-                    // Add a marker for each point
-                    var marker = {latLng: society.location.coordinates.reverse(), name: society.name}
-                    scope.map.addMarker(society.id, marker);
-                });
-
-                // Map IDs to colors
-                var colorMap = colorMapService.generateColorMap(societyIds);
-                scope.map.series.markers[0].setValues(colorMap);
             };
 
-            if(attrs.societies) {
-                // Update markers when societies change
-                scope.$watchCollection('societies', function(oldvalue, newvalue) {
-                    scope.addMarkers();
+            var showMap = function(scope) {
+                scope.map = $('#' + mapDivId).vectorMap({
+                    map: 'tdwg-level2_mill_en',
+                    backgroundColor: 'white',
+                    series: {
+                        markers: [{
+                            attribute: 'fill'
+                        }]
+                    },
+                    regionStyle: {
+                      initial: {
+                        fill: '#428bca',
+                        "fill-opacity": 1,
+                        stroke: '#357ebd',
+                        "stroke-width": 0,
+                        "stroke-opacity": 1
+                      },
+                      hover: {
+                        "fill-opacity": 0.8
+                      },
+                      selected: {
+                        fill: '#113'
+                      },
+                      selectedHover: {
+                      }
+                    },
+                    onRegionOver: function(e, code) {
+                        if(attrs.region) {
+                            scope.$apply(function () {
+                                scope.region = code;
+                            });
+                        }
+                    },
+                    onRegionSelected: function(e, code, isSelected, selectedRegionCodes) {
+                        if(scope.updatesEnabled && attrs.selectedRegions) {
+                            scope.localRegions = selectedRegionCodes.map(function(code) {
+                                return {
+                                    code: code,
+                                    name: scope.map.getRegionName(code)
+                                };
+                            });
+                            var dirty = scope.checkDirty();
+                            if(dirty) {
+                                scope.$apply(function() {
+                                    scope.selectedRegions = angular.copy(scope.localRegions);
+                                });
+                            }
+                        }
+                    },
+                    regionsSelectable: true
+                }).vectorMap('get','mapObject');
+
+                scope.addMarkers = function() {
+                    scope.map.removeAllMarkers();
+                    if(!scope.societies) {
+                        return;
+                    }
+
+                    // get the society IDs
+                    var societyIds = scope.societies.map(function(societyResult) {
+                        return societyResult.society.id;
+                    });
+
+                    scope.societies.forEach(function(societyResult) {
+                        var society = societyResult.society;
+                        // Add a marker for each point
+                        var marker = {latLng: society.location.coordinates.reverse(), name: society.name}
+                        scope.map.addMarker(society.id, marker);
+                    });
+
+                    // Map IDs to colors
+                    var colorMap = colorMapService.generateColorMap(societyIds);
+                    scope.map.series.markers[0].setValues(colorMap);
+                };
+
+                if(attrs.societies) {
+                    // Update markers when societies change
+                    scope.$watchCollection('societies', function(oldvalue, newvalue) {
+                        scope.addMarkers();
+                    });
+                }
+
+                if(attrs.selectedRegions) {
+                    scope.$watchCollection('selectedRegions', function(oldvalue, newvalue) {
+                        var dirty = scope.checkDirty();
+                        if(dirty) {
+                            // update the local variable first
+                            scope.localRegions = angular.copy(scope.selectedRegions);
+
+                            // then update the UI
+                            scope.updatesEnabled = false;
+                            var regionCodes = scope.localRegions.map(function(region){
+                                return region.code;
+                            });
+                            scope.map.clearSelectedRegions();
+                            scope.map.setSelectedRegions(regionCodes);
+                            scope.updatesEnabled = true;
+                        }
+                    });
+                }
+                scope.$on('$destroy', function() {
+                    hideMap(scope);
                 });
-            }
+                scope.map.updateSize();
+            };
 
-            if(attrs.selectedRegions) {
-                scope.$watchCollection('selectedRegions', function(oldvalue, newvalue) {
-                    var dirty = scope.checkDirty();
-                    if(dirty) {
-                        // update the local variable first
-                        scope.localRegions = angular.copy(scope.selectedRegions);
-
-                        // then update the UI
-                        scope.updatesEnabled = false;
-                        var regionCodes = scope.localRegions.map(function(region){
-                            return region.code;
-                        });
-                        scope.map.clearSelectedRegions();
-                        scope.map.setSelectedRegions(regionCodes);
-                        scope.updatesEnabled = true;
+            // Handle visibility toggle
+            // This is necessary for results page where element is in the DOM but not visible.
+            var initiallyVisible = false;
+            // If we have a bound variable to toggle visibility, watch for changes to it
+            if(attrs.visible) {
+                // 'visible' attribute was bound in the tag
+                // use the scope value and watch for changes
+                initiallyVisible = scope.visible;
+                scope.$watch('visible', function(oldValue, newValue) {
+                    if(scope.visible) {
+                        showMap(scope);
+                    } else {
+                        hideMap(scope);
                     }
                 });
+            } else {
+               // tag does not bind a 'visible' attribute, default to true
+                initiallyVisible = true;
             }
-            scope.$on('mapTabActivated', function(event, args) {
-                scope.map.updateSize();
-            });
 
-            scope.$on('$destroy', function() {
-                scope.map.remove();
-
-            });
+            if(initiallyVisible) {
+                showMap(scope);
+            }
         }
 
         return {
@@ -125,7 +155,8 @@ angular.module('dplaceMapDirective', [])
                 societies: '=',
                 region: '=',
                 selectedRegions: '=',
-                mapDivId: '@'
+                mapDivId: '@',
+                visible: '='
             },
             link: link
         };

--- a/dplace_app/static/partials/societies.html
+++ b/dplace_app/static/partials/societies.html
@@ -44,8 +44,8 @@
                 </table>
             </div>
         </tab>
-        <tab heading="Map" select="resizeMap()">
-            <dplace-map societies="results.societies" map-div-id="result-map"></dplace-map>
+        <tab heading="Map" select="visible=true" deselect="visible=false">
+            <dplace-map societies="results.societies" map-div-id="result-map" visible="visible"></dplace-map>
         </tab>
         <tab heading="Download" select="generateDownloadLinks()">
             <div class="row">


### PR DESCRIPTION
Fixes #175

The ‘visible’ attribute is 2-way-bound and used to initialize the map
only when it will be visible. This way, firefox doesn’t complain about
SVG methods called on elements that aren’t on screen.

Binding with a default value in a directive is awkward, since we’re
unable to assign to it if it’s not bound to anything, so there are a
few workarounds.
