### PR TITLE
Include language_family in language objects (incl results)

### DIFF
--- a/dplace_app/api_views.py
+++ b/dplace_app/api_views.py
@@ -42,7 +42,7 @@ class VariableCodeDescriptionViewSet(viewsets.ReadOnlyModelViewSet):
 # Can filter by code, code__variable, or society
 class VariableCodedValueViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = VariableCodedValueSerializer
-    filter_fields = ('variable','coded_value','code','society','code',)
+    filter_fields = ('variable','coded_value','code','society',)
     # Avoid additional database trips by select_related for foreign keys
     queryset = VariableCodedValue.objects.select_related('variable').select_related('code').all()
 
@@ -93,7 +93,7 @@ class LanguageClassificationViewSet(viewsets.ReadOnlyModelViewSet):
 
 class LanguageViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = LanguageSerializer
-    filter_fields = ('name', 'iso_code', 'society',)
+    filter_fields = ('name', 'iso_code', 'societies',)
     queryset = Language.objects.all()
 
 class LanguageTreeViewSet(viewsets.ReadOnlyModelViewSet):

--- a/dplace_app/models.py
+++ b/dplace_app/models.py
@@ -16,13 +16,6 @@ class ISOCode(models.Model):
     class Meta:
         verbose_name = "ISO Code"
 
-SOCIETY_SOURCES = (
-    ('EA', 'EA'),
-    ('EA_Korotayev', 'EA_Korotayev'),
-    ('EA_Bodarenko', 'EA_Bodarenko'),
-    ('Binford', 'Binford'),
-)
-
 class Society(models.Model):
     ext_id = models.CharField('External ID', unique=True, max_length=10)
     name = models.CharField('Name', db_index=True, max_length=200)
@@ -199,7 +192,7 @@ class VariableCodedValue(models.Model):
 
     """
     variable = models.ForeignKey('VariableDescription', related_name="values")
-    society = models.ForeignKey('Society', limit_choices_to={'source__in': [x[0] for x in SOCIETY_SOURCES]}, null=True)
+    society = models.ForeignKey('Society', null=True)
     coded_value = models.CharField(max_length=100, db_index=True, null=False, default='.')
     code = models.ForeignKey('VariableCodeDescription', db_index=True, null=True)
     source = models.ForeignKey('Source', null=True)

--- a/dplace_app/serializers.py
+++ b/dplace_app/serializers.py
@@ -68,6 +68,7 @@ class LanguageClassSerializer(serializers.ModelSerializer):
         model = LanguageClass
 
 class LanguageSerializer(serializers.ModelSerializer):
+    language_family = LanguageClassSerializer(source='languageclassification_set.first.class_family')
     class Meta:
         model = Language
 


### PR DESCRIPTION
Fixes #164 

language_family is now part of the LanguageSerializer. Language JSON objects will look like this:
```json
{
  "id": 4, 
  "iso_code": 4, 
  "name": "Chenoua",
  "language_family": {
    "id": 1, 
    "language_count": 112, 
    "level": 1, 
    "name": "Afro-Asiatic", 
    "parent": null
  }
}
```

If we need to add subfamily or subsubfamily, those could be done the same way.