### PR TITLE
Adjust map region color to a light gray

### DIFF
--- a/dplace_app/static/js/directives.js
+++ b/dplace_app/static/js/directives.js
@@ -231,7 +231,7 @@ angular.module('dplaceMapDirective', [])
                     },
                     regionStyle: {
                       initial: {
-                        fill: '#428bca',
+                        fill: '#C0C6C6',
                         "fill-opacity": 1,
                         stroke: '#357ebd',
                         "stroke-width": 0,


### PR DESCRIPTION
Fixes #160 - but colors choices are always divisive. This can easily be adjusted if the group decides on a color.