### PR TITLE
Avoid printing newly-created EnvironmentalVariable objects to console

### DIFF
--- a/dplace_app/load/environmental.py
+++ b/dplace_app/load/environmental.py
@@ -126,7 +126,6 @@ def create_environmental_variables():
             obj, created = EnvironmentalVariable.objects.get_or_create(name=var_dict['name'],units=var_dict['units'])
             obj.category = env_category
             obj.save()
-            print obj
         else:
             EnvironmentalVariable.objects.get_or_create(name=var_dict['name'],units=var_dict['units']) 
 


### PR DESCRIPTION
Printing the object isn't necessary and fails in the clean vagrant vm.

Fixes #190