### PR TITLE
Adding tooltip & time scale for phylogenies

### DIFF
--- a/dplace_app/api_views.py
+++ b/dplace_app/api_views.py
@@ -100,6 +100,51 @@ class LanguageTreeViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = LanguageTreeSerializer
     filter_fields = ('name',)
     queryset = LanguageTree.objects.all()
+
+#not sure if we need to keep this code since it isn't used at the moment
+#but could come in handy in the future
+def get_language_trees_from_query_dict(query_dict):
+    if 'language_ids' in query_dict:
+        language_ids = [int(x) for x in query_dict['language_ids']]
+        trees = LanguageTree.objects.filter(languages__pk__in=language_ids).distinct()
+    else:
+        trees = None
+    return trees
+    
+#not used at the moment; not sure if needs to be kept
+@api_view(['POST'])
+@permission_classes((AllowAny,))
+def trees_from_languages(request):
+    from ete2 import Tree
+    trees = get_language_trees_from_query_dict(request.DATA)
+    if 'language_ids' in request.DATA:
+        languages = request.DATA['language_ids']
+        for t in trees:
+            langs_in_tree = [str(l.iso_code.iso_code) for l in t.languages.all() if l.id in languages] 
+            newick = Tree(t.newick_string)
+            #only works if tips use isocodes
+            try:
+                newick.prune(langs_in_tree, preserve_branch_length=True)
+            except ValueError as e:
+                print e
+                print t.name
+                continue
+            t.newick_string = newick.write(format=5)
+    return Response(LanguageTreeSerializer(trees, many=True).data,)
+  
+#returns trees that contain the societies from the SocietyResultSet  
+def trees_from_languages_array(language_ids):
+    from ete2 import Tree
+    trees = LanguageTree.objects.filter(languages__pk__in=language_ids).distinct()
+    for t in trees:
+        langs_in_tree = [str(l.iso_code.iso_code) for l in t.languages.all() if l.id in language_ids]
+        newick = Tree(t.newick_string)
+        try:
+            newick.prune(langs_in_tree, preserve_branch_length=True)
+        except:
+            continue
+        t.newick_string = newick.write(format=5)
+    return trees
     
 def result_set_from_query_dict(query_dict):
     result_set = SocietyResultSet()
@@ -161,6 +206,15 @@ def result_set_from_query_dict(query_dict):
                 result_set.add_geographic_region(society, region)
     # Filter the results to those that matched all criteria
     result_set.finalize(criteria)
+    
+    #search for language trees
+    language_ids = []
+    for s in result_set.societies:
+        if s.society.language:
+            language_ids.append(s.society.language.id)
+    trees = trees_from_languages_array(language_ids)
+    for t in trees:
+        result_set.add_language_tree(t)
     return result_set
 
 # search/filter APIs
@@ -182,31 +236,6 @@ class GeographicRegionViewSet(viewsets.ReadOnlyModelViewSet):
     model = GeographicRegion
     filter_class = GeographicRegionFilter
 
-def get_language_trees_from_query_dict(query_dict):
-    if 'language_ids' in query_dict:
-        language_ids = [int(x) for x in query_dict['language_ids']]
-        trees = LanguageTree.objects.filter(languages__pk__in=language_ids).distinct()
-    else:
-        trees = None
-    return trees
-    
-@api_view(['POST'])
-@permission_classes((AllowAny,))
-def trees_from_languages(request):
-    from ete2 import Tree
-    trees = get_language_trees_from_query_dict(request.DATA)
-    if 'language_ids' in request.DATA:
-        languages = request.DATA['language_ids']
-        for t in trees:
-            langs_in_tree = [str(l.iso_code.iso_code) for l in t.languages.all() if l.id in languages] 
-            newick = Tree(t.newick_string)
-            #only works if tips use isocodes
-            try:
-                newick.prune(langs_in_tree, preserve_branch_length=True)
-            except:
-                continue
-            t.newick_string = newick.write(format=5)
-    return Response(LanguageTreeSerializer(trees, many=True).data,)
     
 @api_view(['GET'])
 @permission_classes((AllowAny,))
@@ -245,24 +274,6 @@ def newick_tree(key):
     except ValueError:
         tree = tree
     return tree
-
-@api_view(['GET'])
-@permission_classes((AllowAny,))
-def get_newick_trees(request):
-    from ete2 import Tree
-    trees = get_language_trees_from_query_dict(request.DATA)
-    if 'language_ids' in request.DATA:
-        languages = request.DATA['language_ids']
-        for t in trees:
-            langs_in_tree = [str(l.iso_code.iso_code) for l in t.languages.all() if l.id in languages] 
-            newick = Tree(t.newick_string)
-            #only works if tips use isocodes
-            try:
-                newick.prune(langs_in_tree, preserve_branch_length=True)
-            except:
-                continue
-            t.newick_string = newick.write(format=5)
-    return Response(LanguageTreeSerializer(trees, many=True).data,)
 
 @api_view(['GET'])
 @permission_classes((AllowAny,))

--- a/dplace_app/serializers.py
+++ b/dplace_app/serializers.py
@@ -92,8 +92,8 @@ class GeographicRegionSerializer(gis_serializers.GeoModelSerializer):
         fields = ('id','level_2_re','count','region_nam','continent','tdwg_code')
 
 class LanguageTreeSerializer(serializers.ModelSerializer):
-    languages = LanguageSerializer(source='languages', many=True)
-    class Meta:
+   languages = LanguageSerializer(source='languages', many=True)   
+   class Meta:
         model = LanguageTree
         fields = ('id','name','languages', 'newick_string')
 
@@ -147,6 +147,7 @@ class SocietyResultSet(object):
         self.environmental_variables = set()
         self.languages = set()
         self.geographic_regions = set()
+        self.language_trees = set()
 
     def _get_society_result(self,society):
         if society.id not in self._society_results.keys():
@@ -168,7 +169,10 @@ class SocietyResultSet(object):
     def add_geographic_region(self,society,geographic_region):
         self.geographic_regions.add(geographic_region)
         self._get_society_result(society).add_geographic_region(geographic_region)
-
+   
+    def add_language_tree(self,language_tree):
+        self.language_trees.add(language_tree)
+    
     def finalize(self,criteria):
         self.societies = [x for x in self._society_results.values() if x.includes_criteria(criteria)]
 
@@ -198,3 +202,6 @@ class SocietyResultSetSerializer(serializers.Serializer):
     languages = LanguageSerializer(many=True)
     # Geographic Regions - does not map to a more specific value
     geographic_regions = GeographicRegionSerializer(many=True)
+    #language trees for this society result set
+    language_trees = LanguageTreeSerializer(many=True)
+

--- a/dplace_app/static/css/dplace.css
+++ b/dplace_app/static/css/dplace.css
@@ -1,3 +1,16 @@
+div.tooltip {
+    position:absolute;
+    text-align:center;
+    width:auto;
+    height:auto;
+    padding:2px;
+    padding-left:10px;
+    padding-right:10px;
+    font-size:13px;
+    background:#E0E0E0;
+    border:0px;
+}
+
 .row-margin-top {
     margin-top: 5px;
 }

--- a/dplace_app/static/js/controllers/search.js
+++ b/dplace_app/static/js/controllers/search.js
@@ -106,20 +106,21 @@ function SearchCtrl($scope, colorMapService, searchModelService, FindSocieties, 
         });
     };
 
+    //not used at the moment
     function searchForLanguageTrees() {
         var languageIDs = $scope.searchModel.getSocieties().filter(function (container) {
             return container.society.language != null;
         }).map(function (container) {
             return container.society.language.id;
         });
-        $scope.searchModel.results.languageTrees = TreesFromLanguages.find({language_ids: languageIDs}, addTreesToSocieties);
+        $scope.searchModel.results.language_trees = TreesFromLanguages.find({language_ids: languageIDs}, addTreesToSocieties);
     }
     
     function addTreesToSocieties() {
         $scope.searchModel.getSocieties().forEach(function (container) {
             var language = container.society.language;
             if(language != null) {
-                container.society.trees = $scope.searchModel.results.languageTrees.filter(function (tree) {
+                container.society.trees = $scope.searchModel.results.language_trees.filter(function (tree) {
                     return tree.languages.some(function (item) {
                         return angular.equals(language, item);
                     });
@@ -146,7 +147,7 @@ function SearchCtrl($scope, colorMapService, searchModelService, FindSocieties, 
         $scope.enableSearchButton();
         $scope.getCodeIDs();
         $scope.assignColors();
-        searchForLanguageTrees();
+        addTreesToSocieties();
         $scope.switchToResults();
     };
 

--- a/dplace_app/static/js/controllers/societies.js
+++ b/dplace_app/static/js/controllers/societies.js
@@ -43,97 +43,18 @@ function SocietiesCtrl($scope, searchModelService, LanguageClass) {
     
     $scope.treeSelected = function() {
         $scope.$broadcast('treeSelected', {tree: $scope.results.selectedTree});
+        d3.select(".tree-legend-DL").html('');
         $scope.treeDownload();
     };
     
     $scope.treeDownload = function() {
-        var legend = d3.select(".tree-legend-DL")
-            .append("svg:g")
-            .attr("transform", function() {
-                return 'translate(0,0)';
-            });
-        var prev_codes = 0;
-        var final_transform = 0;
-        for (var key in $scope.results.code_ids) {
-            container_g = legend.append("svg:g")
-                .attr("transform", function () {
-                    translate = (prev_codes * 25) + 25;
-                    return 'translate(0,'+translate+')';
-                });
-            container_g.append("svg:text")
-                .text($scope.results.code_ids[key].name)
-        
-            for (var i = 0; i < $scope.results.code_ids[key].length; i++) {
-            g = container_g.append("svg:g")
-                .attr("transform", function() {
-                    if (i == 0) 
-                        return 'translate(0,10)';
-                    else {
-                        j = (i*25)+10;
-                        final_transform = j;
-                        return 'translate(0,'+j+')';
-                    }
-                });
-            var fill = function() {
-                var value = $scope.results.code_ids[key][i].code;
-                    var hue = value * 240 / $scope.results.code_ids[key].length;
-                    return 'hsl('+hue+',100%,50%)';
-            }              
-            g.append("svg:circle")
-                .attr("cx", "10")
-                .attr("cy", "10")
-                .attr("r", "4.5")
-                .attr("stroke", "#000")
-                .attr("stroke-width", "0.5")
-                .attr("fill", function() {
-                    var value = $scope.results.code_ids[key][i].code;
-                    var hue = value * 240 / $scope.results.code_ids[key].length;
-                    return 'hsl('+hue+',100%,50%)';
-                });
-            g.append("svg:text")
-                .attr("x", "20")
-                .attr("y", "15")
-                .text($scope.results.code_ids[key][i].description);
-            }        
-            prev_codes = $scope.results.code_ids[key].length;
-        }
-        d3_height = d3.select(".phylogeny").style("height");
-        d3_height = parseInt(d3_height);
-        
-        d3.select(".tree-download").html('');
         var tree_svg = d3.select(".phylogeny")
             .attr("version", 1.1)
             .attr("xmlns", "http://www.w3.org/2000/svg")
             .node().parentNode.innerHTML;
-        tree_svg = tree_svg.substring(tree_svg.indexOf("<svg xml"));
-        
-        //this changes the height of the svg for the download, so it includes the legend
-        var code_count = 0;
-        for (var key in $scope.results.code_ids) {
-            code_count = code_count + $scope.results.code_ids[key].length;
-        }
-        append_height = tree_svg.substring(0, tree_svg.indexOf("height="));
-        digits = d3_height.toString().length;
-        d3_height += (code_count * 50);
-        append_height = append_height.concat("height="+'"'+d3_height+'"');
-        to_append = tree_svg.substring(tree_svg.indexOf("height=")+9+digits);
-        append_height = append_height.concat(to_append);
-                
-        //this changes the position of the phylogeny to make room for the legend
-        change_transform = append_height.substring(0, append_height.indexOf("transform="));
-        change_transform = change_transform.concat('transform="translate' + '(0,' + (final_transform+50));
-        transform_length = append_height.substring(append_height.indexOf("transform="), append_height.indexOf(")"));
-        to_append = append_height.substring(append_height.indexOf("transform=")+transform_length.length);
-        change_transform = change_transform.concat(to_append);
-        
-       //add legend to download
-       var tree_legend = d3.select(".tree-legend-DL").node().innerHTML;
-       console.log(change_transform);
-       add_legend = change_transform.substring(0, change_transform.indexOf(">"));
-       add_legend = add_legend.concat(">" + tree_legend);
-       add_legend = add_legend.concat(change_transform.substring(change_transform.indexOf(">")+1));
-
-       var imgsrc = 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(add_legend)));
+         tree_svg = tree_svg.substring(tree_svg.indexOf("<svg xml"));
+         tree_svg = tree_svg.substring(0, tree_svg.indexOf("</svg>"));
+        var imgsrc = 'data:image/svg:xml;base64,' + window.btoa(unescape(encodeURIComponent(tree_svg)));
         d3.select(".tree-download").append("a")
             .attr("class", "btn btn-info btn-dplace-download")
             .attr("download", "tree.svg")

--- a/dplace_app/static/js/controllers/societies.js
+++ b/dplace_app/static/js/controllers/societies.js
@@ -53,6 +53,24 @@ function SocietiesCtrl($scope, searchModelService, LanguageClass) {
     
     $scope.treeSelected = function() {
         $scope.$broadcast('treeSelected', {tree: $scope.results.selectedTree});
+        $scope.treeDownload();
+    };
+    
+    $scope.treeDownload = function() {
+        d3.select(".tree-download").html('');
+        var tree_svg = d3.select("language-phylogeny").select(".phylogeny")
+            .attr("version", 1.1)
+            .attr("xmlns", "http://www.w3.org/2000/svg")
+            .node().parentNode.innerHTML;
+        tree_svg = tree_svg.substring(tree_svg.indexOf("<svg xml"));
+        console.log(tree_svg);
+        
+        var imgsrc = 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(tree_svg)));
+        d3.select(".tree-download").append("a")
+            .attr("class", "btn btn-info btn-dplace-download")
+            .attr("download", "tree.svg")
+            .attr("href", imgsrc)
+            .html("Download Phylogeny");
     };
 
     $scope.generateDownloadLinks = function() {

--- a/dplace_app/static/js/controllers/societies.js
+++ b/dplace_app/static/js/controllers/societies.js
@@ -47,19 +47,38 @@ function SocietiesCtrl($scope, searchModelService, LanguageClass) {
     };
     
     $scope.treeDownload = function() {
-        var legend = d3.select("language-phylogeny").select(".phylogeny")
+        var legend = d3.select(".tree-legend-DL")
             .append("svg:g")
-            .attr("class", "tree-legend-DL")
             .attr("transform", function() {
                 return 'translate(0,0)';
             });
+        var prev_codes = 0;
+        var final_transform = 0;
         for (var key in $scope.results.code_ids) {
-            
-            for (var i = 0; i < $scope.results.code_ids[key].length; i++) {
-            g = legend.append("svg:g")
-                .attr("transform", function() {
-                    return 'translate(0,'+i*25+')';
+            container_g = legend.append("svg:g")
+                .attr("transform", function () {
+                    translate = (prev_codes * 25) + 25;
+                    return 'translate(0,'+translate+')';
                 });
+            container_g.append("svg:text")
+                .text($scope.results.code_ids[key].name)
+        
+            for (var i = 0; i < $scope.results.code_ids[key].length; i++) {
+            g = container_g.append("svg:g")
+                .attr("transform", function() {
+                    if (i == 0) 
+                        return 'translate(0,10)';
+                    else {
+                        j = (i*25)+10;
+                        final_transform = j;
+                        return 'translate(0,'+j+')';
+                    }
+                });
+            var fill = function() {
+                var value = $scope.results.code_ids[key][i].code;
+                    var hue = value * 240 / $scope.results.code_ids[key].length;
+                    return 'hsl('+hue+',100%,50%)';
+            }              
             g.append("svg:circle")
                 .attr("cx", "10")
                 .attr("cy", "10")
@@ -76,12 +95,10 @@ function SocietiesCtrl($scope, searchModelService, LanguageClass) {
                 .attr("y", "15")
                 .text($scope.results.code_ids[key][i].description);
             }        
+            prev_codes = $scope.results.code_ids[key].length;
         }
-        
-        d3.select(".tree-legend.DL")
-            .attr("transform", function() {
-                return 'translate(0,0)';
-            });
+        d3_height = d3.select(".phylogeny").style("height");
+        d3_height = parseInt(d3_height);
         
         d3.select(".tree-download").html('');
         var tree_svg = d3.select(".phylogeny")
@@ -90,16 +107,33 @@ function SocietiesCtrl($scope, searchModelService, LanguageClass) {
             .node().parentNode.innerHTML;
         tree_svg = tree_svg.substring(tree_svg.indexOf("<svg xml"));
         
+        //this changes the height of the svg for the download, so it includes the legend
+        var code_count = 0;
+        for (var key in $scope.results.code_ids) {
+            code_count = code_count + $scope.results.code_ids[key].length;
+        }
         append_height = tree_svg.substring(0, tree_svg.indexOf("height="));
-        d3_height = d3.select(".phylogeny").style("height");
-        d3_height = parseInt(d3_height);
         digits = d3_height.toString().length;
-        d3_height += 500;
+        d3_height += (code_count * 50);
         append_height = append_height.concat("height="+'"'+d3_height+'"');
         to_append = tree_svg.substring(tree_svg.indexOf("height=")+9+digits);
         append_height = append_height.concat(to_append);
-        console.log(append_height);
-        var imgsrc = 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(append_height)));
+                
+        //this changes the position of the phylogeny to make room for the legend
+        change_transform = append_height.substring(0, append_height.indexOf("transform="));
+        change_transform = change_transform.concat('transform="translate' + '(0,' + (final_transform+50));
+        transform_length = append_height.substring(append_height.indexOf("transform="), append_height.indexOf(")"));
+        to_append = append_height.substring(append_height.indexOf("transform=")+transform_length.length);
+        change_transform = change_transform.concat(to_append);
+        
+       //add legend to download
+       var tree_legend = d3.select(".tree-legend-DL").node().innerHTML;
+       console.log(change_transform);
+       add_legend = change_transform.substring(0, change_transform.indexOf(">"));
+       add_legend = add_legend.concat(">" + tree_legend);
+       add_legend = add_legend.concat(change_transform.substring(change_transform.indexOf(">")+1));
+
+       var imgsrc = 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(add_legend)));
         d3.select(".tree-download").append("a")
             .attr("class", "btn btn-info btn-dplace-download")
             .attr("download", "tree.svg")

--- a/dplace_app/static/js/controllers/societies.js
+++ b/dplace_app/static/js/controllers/societies.js
@@ -1,7 +1,7 @@
 function SocietiesCtrl($scope, searchModelService, LanguageClass) {
     $scope.results = searchModelService.getModel().getResults();
     $scope.query = searchModelService.getModel().getQuery();
-
+    console.log($scope.results);
     if ($scope.query.variable_codes) {
         $scope.code_ids = {};
         for (var i = 0; i < $scope.query.variable_codes.length; i++) {
@@ -57,14 +57,59 @@ function SocietiesCtrl($scope, searchModelService, LanguageClass) {
     };
     
     $scope.treeDownload = function() {
+        var legend = d3.select("language-phylogeny").select(".phylogeny")
+            .append("svg:g")
+            .attr("class", "tree-legend-DL")
+            .attr("transform", function() {
+                return 'translate(0,0)';
+            });
+        total_codes = 0;
+        for (var key in $scope.code_ids) {
+            
+            for (var i = 0; i < $scope.code_ids[key].length; i++) {
+            total_codes = total_codes++;
+            g = legend.append("svg:g")
+                .attr("transform", function() {
+                    return 'translate(0,'+i*25+')';
+                });
+            g.append("svg:circle")
+                .attr("cx", "10")
+                .attr("cy", "10")
+                .attr("r", "4.5")
+                .attr("stroke", "#000")
+                .attr("stroke-width", "0.5")
+                .attr("fill", function() {
+                    var value = $scope.code_ids[key][i].code;
+                    var hue = value * 240 / $scope.code_ids[key].length;
+                    return 'hsl('+hue+',100%,50%)';
+                });
+            g.append("svg:text")
+                .attr("x", "20")
+                .attr("y", "15")
+                .text($scope.code_ids[key][i].description);
+            }        
+        }
+        
+        d3.select(".tree-legend.DL")
+            .attr("transform", function() {
+                return 'translate(0,'+total_codes*25+")";
+            });
+        
         d3.select(".tree-download").html('');
-        var tree_svg = d3.select("language-phylogeny").select(".phylogeny")
+        var tree_svg = d3.select(".phylogeny")
             .attr("version", 1.1)
             .attr("xmlns", "http://www.w3.org/2000/svg")
             .node().parentNode.innerHTML;
         tree_svg = tree_svg.substring(tree_svg.indexOf("<svg xml"));
-        console.log(tree_svg);
         
+        append_height = tree_svg.substring(0, tree_svg.indexOf("height="));
+        d3_height = d3.select(".phylogeny").style("height");
+                console.log(parseInt(d3_height));
+        d3_height += 500;
+        append_height = append_height.concat("height="+d3_height);
+        append_height = append_height.concat(tree_svg.substring(tree_svg.indexOf("height=")+9+d3_height.length));
+        console.log(append_height);
+
         var imgsrc = 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(tree_svg)));
         d3.select(".tree-download").append("a")
             .attr("class", "btn btn-info btn-dplace-download")

--- a/dplace_app/static/js/controllers/societies.js
+++ b/dplace_app/static/js/controllers/societies.js
@@ -1,15 +1,11 @@
 function SocietiesCtrl($scope, searchModelService, LanguageClass) {
     $scope.results = searchModelService.getModel().getResults();
     $scope.query = searchModelService.getModel().getQuery();
-
-    console.log($scope.results);
-
     $scope.variables = [];
     console.log($scope.results);
     if ($scope.results.variable_descriptions) {
         $scope.variables = $scope.variables.concat($scope.results.variable_descriptions);
     }
-    
         
     if ($scope.query.environmental_filters) {
         $scope.variables = $scope.variables.concat($scope.results.environmental_variables);
@@ -57,11 +53,9 @@ function SocietiesCtrl($scope, searchModelService, LanguageClass) {
             .attr("transform", function() {
                 return 'translate(0,0)';
             });
-        total_codes = 0;
-        for (var key in $scope.code_ids) {
+        for (var key in $scope.results.code_ids) {
             
-            for (var i = 0; i < $scope.code_ids[key].length; i++) {
-            total_codes = total_codes++;
+            for (var i = 0; i < $scope.results.code_ids[key].length; i++) {
             g = legend.append("svg:g")
                 .attr("transform", function() {
                     return 'translate(0,'+i*25+')';
@@ -73,20 +67,20 @@ function SocietiesCtrl($scope, searchModelService, LanguageClass) {
                 .attr("stroke", "#000")
                 .attr("stroke-width", "0.5")
                 .attr("fill", function() {
-                    var value = $scope.code_ids[key][i].code;
-                    var hue = value * 240 / $scope.code_ids[key].length;
+                    var value = $scope.results.code_ids[key][i].code;
+                    var hue = value * 240 / $scope.results.code_ids[key].length;
                     return 'hsl('+hue+',100%,50%)';
                 });
             g.append("svg:text")
                 .attr("x", "20")
                 .attr("y", "15")
-                .text($scope.code_ids[key][i].description);
+                .text($scope.results.code_ids[key][i].description);
             }        
         }
         
         d3.select(".tree-legend.DL")
             .attr("transform", function() {
-                return 'translate(0,'+total_codes*25+")";
+                return 'translate(0,0)';
             });
         
         d3.select(".tree-download").html('');
@@ -98,13 +92,14 @@ function SocietiesCtrl($scope, searchModelService, LanguageClass) {
         
         append_height = tree_svg.substring(0, tree_svg.indexOf("height="));
         d3_height = d3.select(".phylogeny").style("height");
-                console.log(parseInt(d3_height));
+        d3_height = parseInt(d3_height);
+        digits = d3_height.toString().length;
         d3_height += 500;
-        append_height = append_height.concat("height="+d3_height);
-        append_height = append_height.concat(tree_svg.substring(tree_svg.indexOf("height=")+9+d3_height.length));
+        append_height = append_height.concat("height="+'"'+d3_height+'"');
+        to_append = tree_svg.substring(tree_svg.indexOf("height=")+9+digits);
+        append_height = append_height.concat(to_append);
         console.log(append_height);
-
-        var imgsrc = 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(tree_svg)));
+        var imgsrc = 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(append_height)));
         d3.select(".tree-download").append("a")
             .attr("class", "btn btn-info btn-dplace-download")
             .attr("download", "tree.svg")

--- a/dplace_app/static/js/directives.js
+++ b/dplace_app/static/js/directives.js
@@ -34,7 +34,6 @@ angular.module('languagePhylogenyDirective', [])
                 var labels = d3.select("language-phylogeny").append("svg:svg")
                         .attr("width", w+300)
                         .attr("height", 15)
-                        //.attr("style", "position:absolute; background-color:#fff")
                         .attr("id", "varLabels")
                         .attr("transform", "translate(-40, 0)");
                 keysWritten = 1;
@@ -60,6 +59,7 @@ angular.module('languagePhylogenyDirective', [])
                 var vis = d3.select("language-phylogeny").append("svg:svg")
                     .attr("width", w+300)
                     .attr("height", h+30)
+                    .attr("class", "phylogeny")
                     .append("svg:g")
                     .attr("transform", "translate(2, 0)");
                     

--- a/dplace_app/static/js/directives.js
+++ b/dplace_app/static/js/directives.js
@@ -74,11 +74,19 @@ angular.module('languagePhylogenyDirective', [])
                 var yscale = d3.scale.linear()
                     .domain([0, d3.max(rootDists)])
                     .range([0, w]);
+                var leafDistFromRoot = 0;
                 nodes.forEach(function(node) {
+                    if (node.rootDist > leafDistFromRoot)
+                        leafDistFromRoot = node.rootDist;
                     node.y = yscale(node.rootDist);
                 });
                 
+                //calculate time scale
+                var timeScaleYears = leafDistFromRoot * 100; //convert to years
+                var pixelScale = (w / timeScaleYears) * 100;
+                
                 var links = tree.links(nodes);
+                console.log(nodes);
                 var link = vis.selectAll("path.link")
                     .data(links)
                     .enter().append("svg:path")
@@ -90,8 +98,12 @@ angular.module('languagePhylogenyDirective', [])
                 var node = vis.selectAll("g.node")
                     .data(nodes)
                     .enter().append("svg:g")
+                    .attr("class", function(n) {
+                        if (n.children) return "inner-node";
+                        else return "leaf-node";
+                    })
                     .attr("transform", function(d) { return "translate(" + d.y + ", "+ d.x + ")"; });
-                    
+                
                 translate = 0;
                 if (scope.query.variable_codes) {
                     for (var key in scope.results.code_ids) {
@@ -191,6 +203,23 @@ angular.module('languagePhylogenyDirective', [])
                             .attr("font-family", "Arial")
                             .text(function(d) { return d.name; });
                 });
+                
+                //APPEND LINE HERE
+                line_svg= d3.select('language-phylogeny').append("svg:svg")
+                    .attr("style", "margin-left:100px;");
+                line_svg.append("svg:line")
+                    .attr("x1", "0")
+                    .attr("y1", "0")
+                    .attr("x2", pixelScale)
+                    .attr("y2", "0")
+                    .attr("style", "stroke:#ccc;stroke-width:7;");
+                line_svg.append("svg:text")
+                    .attr("dy", "20")
+                    .attr("dx", function() {
+                        return (pixelScale - 63)/2;
+                    })
+                    .text("100 years");
+                    
                 
                 phyloWidth = d3.select("g").node().getBBox().width;
                 d3.select("#legend")

--- a/dplace_app/static/js/directives.js
+++ b/dplace_app/static/js/directives.js
@@ -99,7 +99,8 @@ angular.module('languagePhylogenyDirective', [])
                             if (society.variable_coded_values.length > 0) {
                                 for (var i = 0; i < society.variable_coded_values.length; i++) {
                                     if (society.variable_coded_values[i].variable == key) {
-                                            var hover_text = society.variable_coded_values[i].code_description.description;
+                                            var hover_text = society.society.name;
+                                            var hover_text_value = society.variable_coded_values[i].code_description.description;
                                             selected.append("svg:circle")
                                                 .attr("r", 4.5)
                                                 .attr("stroke", "#000")
@@ -112,22 +113,25 @@ angular.module('languagePhylogenyDirective', [])
                                                     return 'hsl('+hue+',100%, 50%)';
                                                 })
                                                 .on("mouseover", function() { //need to add text here!
-                                                    translate += 20;
                                                       var g = selected.append("svg:g")
-                                                  .attr("transform", "translate("+translate+", 0)");
-                                                        g.select('text').remove();
+                                                            .attr("transform", "translate(20, -10)");
                                                         g.append("svg:rect")
-                                                        .attr("width", hover_text.length * 10)
-                                                        .attr("height", "23")
-                                                        .attr("fill", "white");
-                                                        g.append("svg:text")
-                                                        .attr("dy", "12")
-                                                        .text(hover_text);
+                                                            .attr("width", hover_text_value.length * 8)
+                                                            .attr("height", "40")
+                                                            .attr("fill", "white");
+                                                        var txt = g.append("svg:text")
+                                                            .attr("dy", "15")
+                                                            .attr("dx", "5")
+                                                        txt.append("svg:tspan")
+                                                            .text(hover_text)
+                                                        txt.append("svg:tspan")
+                                                            .attr("dy", "15")
+                                                            .attr("x", "5")
+                                                            .text(hover_text_value);
                                                   })
                                                   .on("mouseout", function() {
                                                       // Remove the info text on mouse out.
                                                       selected.select('g').remove();
-                                                      translate -= 20;
                                                 })
                                                 
                                                 ; 

--- a/dplace_app/static/js/directives.js
+++ b/dplace_app/static/js/directives.js
@@ -61,7 +61,7 @@ angular.module('languagePhylogenyDirective', [])
                     .attr("height", h+30)
                     .attr("class", "phylogeny")
                     .append("svg:g")
-                    .attr("transform", "translate(2, 0)");
+                    .attr("transform", "translate(5, 5)");
                     
                 var diagonal = rightAngleDiagonal();
                 

--- a/dplace_app/static/js/directives.js
+++ b/dplace_app/static/js/directives.js
@@ -109,6 +109,9 @@ angular.module('languagePhylogenyDirective', [])
                                                 .attr("stroke-width", "0.5")
                                                 .attr("transform", "translate("+translate+", 0)")
                                                 .attr("fill", function(n) {
+                                                    if (society.variable_coded_values[i].code_description.description.indexOf("Missing data") != -1) {
+                                                        return 'hsl(360, 100%, 100%)';
+                                                    }
                                                     value = society.variable_coded_values[i].coded_value;
                                                     hue = value * 240 / scope.code_ids[society.variable_coded_values[i].variable].length;
                                                     return 'hsl('+hue+',100%, 50%)';

--- a/dplace_app/static/js/directives.js
+++ b/dplace_app/static/js/directives.js
@@ -3,6 +3,8 @@ angular.module('languagePhylogenyDirective', [])
         function link(scope, element, attrs) {
             var constructTree = function(langTree) {
                 d3.select("language-phylogeny").html('');
+               
+                
                 var newick = Newick.parse(langTree.newick_string);
                 var rightAngleDiagonal = function() {
                     function diagonal(diagonalPath) {
@@ -99,7 +101,7 @@ angular.module('languagePhylogenyDirective', [])
                             if (society.variable_coded_values.length > 0) {
                                 for (var i = 0; i < society.variable_coded_values.length; i++) {
                                     if (society.variable_coded_values[i].variable == key) {
-                                            var hover_text = society.society.name;
+                                            var society_name = society.society.name + " (" + society.society.iso_code + ")";
                                             var hover_text_value = society.variable_coded_values[i].code_description.description;
                                             selected.append("svg:circle")
                                                 .attr("r", 4.5)
@@ -107,35 +109,21 @@ angular.module('languagePhylogenyDirective', [])
                                                 .attr("stroke-width", "0.5")
                                                 .attr("transform", "translate("+translate+", 0)")
                                                 .attr("fill", function(n) {
-                                                    console.log(i);
                                                     value = society.variable_coded_values[i].coded_value;
                                                     hue = value * 240 / scope.code_ids[society.variable_coded_values[i].variable].length;
                                                     return 'hsl('+hue+',100%, 50%)';
                                                 })
-                                                .on("mouseover", function() { //need to add text here!
-                                                      var g = selected.append("svg:g")
-                                                            .attr("transform", "translate(20, -10)");
-                                                        g.append("svg:rect")
-                                                            .attr("width", hover_text_value.length * 8)
-                                                            .attr("height", "40")
-                                                            .attr("fill", "white");
-                                                        var txt = g.append("svg:text")
-                                                            .attr("dy", "15")
-                                                            .attr("dx", "5")
-                                                        txt.append("svg:tspan")
-                                                            .text(hover_text)
-                                                        txt.append("svg:tspan")
-                                                            .attr("dy", "15")
-                                                            .attr("x", "5")
-                                                            .text(hover_text_value);
+                                                .on("mouseover", function() { 
+                                                     d3.select("body").append("div")
+                                                        .attr("class", "tooltip")
+                                                        .html("<b>"+society_name+":</b><br>"+hover_text_value)
+                                                        .style("left", (d3.event.pageX + 10)+"px")
+                                                        .style("top", (d3.event.pageY + 5)+"px")
+                                                        .style("opacity", .9);
                                                   })
                                                   .on("mouseout", function() {
-                                                      // Remove the info text on mouse out.
-                                                      selected.select('g').remove();
-                                                })
-                                                
-                                                ; 
-
+                                                      d3.select(".tooltip").remove();
+                                                }); 
                                     } 
                                 }
                             }
@@ -198,7 +186,7 @@ angular.module('languagePhylogenyDirective', [])
                             .attr("dy", 4)
                             .attr("font-size", "14px")
                             .attr("font-family", "Arial")
-                            .text(function(d) { return d.name; });  
+                            .text(function(d) { return d.name; });
                 });
                 
                 phyloWidth = d3.select("g").node().getBBox().width;

--- a/dplace_app/static/js/filters.js
+++ b/dplace_app/static/js/filters.js
@@ -1,6 +1,9 @@
 angular.module('dplaceFilters', [])
     .filter('colorNode', function() {
         return function(value, codes) {
+            this_code = codes.filter(function(code) { return code.code == value });
+            if (this_code.length > 0 && this_code[0].description.indexOf("Missing data") != -1)
+                return 'hsl(360, 100%, 100%)';
             var hue = value * 240 / codes.length;
             return 'hsl('+hue+',100%, 50%)';
         }

--- a/dplace_app/static/js/services.js
+++ b/dplace_app/static/js/services.js
@@ -148,6 +148,7 @@ angular.module('dplaceServices', ['ngResource'])
                 }
             });
     })
+    //not used at the moment
     .factory('TreesFromLanguages', function($resource) {
         return $resource(
             '/api/v1/trees_from_languages',

--- a/dplace_app/static/partials/societies.html
+++ b/dplace_app/static/partials/societies.html
@@ -72,7 +72,7 @@
                                                 cx="10"
                                                 cy="10"
                                                 r="4.5"
-                                                fill="{{c.code|colorNode:code}}" //need to figure out how to put right length
+                                                fill="{{c.code|colorNode:code}}" 
                                                 stroke="#000"
                                                 stroke-width="0.5"
                                                 />    
@@ -98,7 +98,7 @@
                                 cx="10"
                                 cy="10"
                                 r="4.5"
-                                fill="{{class.id|colorNode:classifications}}" //need to figure out how to put right length
+                                fill="{{class.id|colorNode:classifications}}" 
                                 stroke="#000"
                                 stroke-width="0.5"
                             />

--- a/dplace_app/static/partials/societies.html
+++ b/dplace_app/static/partials/societies.html
@@ -161,6 +161,7 @@
                 </table>
             </div>
             <language-phylogeny></language-phylogeny>
+            <svg class="tree-legend-DL" style="visibility:hidden"></svg>
         </tab>
         <tab heading="Download" select="generateDownloadLinks()">
             <div class="row">

--- a/dplace_app/static/partials/societies.html
+++ b/dplace_app/static/partials/societies.html
@@ -75,7 +75,7 @@
                                                 fill="{{c.code|colorNode:code}}" //need to figure out how to put right length
                                                 stroke="#000"
                                                 stroke-width="0.5"
-                                            />
+                                                />    
                                         </svg>
                                     </td>
                                     <td>

--- a/dplace_app/static/partials/societies.html
+++ b/dplace_app/static/partials/societies.html
@@ -161,7 +161,7 @@
                 </table>
             </div>
             <language-phylogeny></language-phylogeny>
-            <svg class="tree-legend-DL" style="visibility:hidden"></svg>
+            <div class="tree-legend-DL" style="visibility:hidden"></div>
         </tab>
         <tab heading="Download" select="generateDownloadLinks()">
             <div class="row">

--- a/dplace_app/static/partials/societies.html
+++ b/dplace_app/static/partials/societies.html
@@ -58,6 +58,7 @@
                 >
                 <option value="">Select a Phylogeny</option>
             </select>
+            <div class="tree-download"></div>
 
             <div id="legend" ng-show="results.selectedTree">
                 <table ng-repeat="(id, code) in code_ids">

--- a/dplace_app/static/partials/societies.html
+++ b/dplace_app/static/partials/societies.html
@@ -103,7 +103,7 @@
                 class="form-control"
                 style="width:100%"
                 ng-change="treeSelected()"
-                ng-options="tree.name for tree in results.languageTrees"
+                ng-options="tree.name for tree in results.language_trees"
                 >
                 <option value="">Select a Phylogeny</option>
             </select>


### PR DESCRIPTION
Hovering over marker displays society name and code description.
Also, missing data markers are now white for phylogenies.

I've changed the Find Societies code so that it searches for the language trees as well, instead of having it return the societies and then do another search.  This can be changed back if needed, I haven't deleted any of the old code yet.